### PR TITLE
 Changed from re.search to re.match in db.py

### DIFF
--- a/fabfile/db.py
+++ b/fabfile/db.py
@@ -17,7 +17,7 @@ def _load_db():
    members = dict()
    for node_name in all_hosts:
       for reg,cls in rules.iteritems():
-         if re.search(reg,node_name):
+         if re.match(reg,node_name):
             for cls_name in cls.keys():
                h = members.get(cls_name,[])
                h.append(node_name)
@@ -28,9 +28,13 @@ def _load_db():
    for node_name in all_hosts:
       node_classes = dict()
       for reg,cls in rules.iteritems():
-         if re.search(reg,node_name):
+         if re.match(reg,node_name):
             node_classes.update(cls)
       classes[node_name] = node_classes
+
+   # Sort member lists for a more easy to read diff
+   for cls in members.keys():
+       members[cls].sort()
 
    return dict(classes=classes,members=members)
 

--- a/global/overlay/etc/puppet/cosmos-rules.yaml
+++ b/global/overlay/etc/puppet/cosmos-rules.yaml
@@ -1,2 +1,3 @@
-'ns[0-9]?.mnt.se$':
+# Note that the matching is done with re.match()
+'^ns[0-9]?.mnt.se$':
    nameserver:


### PR DESCRIPTION
because re.search would match on broken regex, nodes that have a part of the name in common with other nodes etc.