### PR TITLE
gpg import with --no-tty

### DIFF
--- a/addhost
+++ b/addhost
@@ -51,7 +51,7 @@ fi
 
 if [ "$cmd_do_bootstrap" = "yes" ]; then
    scp apt/cosmos_1.5-1_all.deb apt/bootstrap-cosmos.sh root@$cmd_hostname:
-   ssh -t root@$cmd_hostname ./bootstrap-cosmos.sh $cmd_fqdn $rrepo $rtag
-   ssh -t root@$cmd_hostname cosmos update
-   ssh -t root@$cmd_hostname cosmos apply
+   ssh root@$cmd_hostname ./bootstrap-cosmos.sh $cmd_fqdn $rrepo $rtag
+   ssh root@$cmd_hostname cosmos update
+   ssh root@$cmd_hostname cosmos apply
 fi

--- a/global/post-tasks.d/015cosmos-trust
+++ b/global/post-tasks.d/015cosmos-trust
@@ -55,10 +55,10 @@ for k in $COSMOS_KEYS/*.pub; do
 
     if [[ ! ${KEYRING[$fp]} ]]; then
 	echo -e "$0: ${bold}Importing new key ${fp}${reset} from ${k}"
-	cosmos gpg --import < $k
+	cosmos gpg --no-tty --import < $k
     elif [[ ${EXPIRED[$fp]} ]]; then
 	echo -e "$0: ${bold}Re-importing expired key ${fp}${reset} from ${k}"
-	cosmos gpg --import < $k
+	cosmos gpg --no-tty --import < $k
     fi
 done
 


### PR DESCRIPTION
With recent GPG versions, a TTY seems to be required to import keys.

Since importing of keys need to work when running from cron, we
pass --no-tty to those commands. This should mean that -t doesn't
have to be passed to SSH on bootstrapping for new Debian hosts
(tested on Raspbian).