### PR TITLE
Rework prepare-iaas-debian

### DIFF
--- a/debian-enable-root.sh
+++ b/debian-enable-root.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# This script is called from prepare-iaas-debian after logging in via ssh as
+# the default "debian" user
+#
+set -ex
+
+sudo cp -r /home/debian/.ssh /root/
+sudo chown -R root:root /root/.ssh
+sudo chmod 700 /root/.ssh
+sudo chmod 600 /root/.ssh/authorized_keys

--- a/debian-setup.sh
+++ b/debian-setup.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# This script is called from prepare-iaas-debian after logging in over ssh as
+# the root user
+#
+set -x
+
+# Get rid of ugly perl messages when running from macOS:
+# ===
+# apt-listchanges: Reading changelogs...
+# perl: warning: Setting locale failed.
+# perl: warning: Please check that your locale settings:
+# 	LANGUAGE = (unset),
+# 	LC_ALL = (unset),
+# 	LC_CTYPE = "UTF-8",
+# 	LC_TERMINAL = "iTerm2",
+# 	LANG = "C.UTF-8"
+#     are supported and installed on your system.
+# perl: warning: Falling back to a fallback locale ("C.UTF-8").
+# ===
+export LC_CTYPE=C.UTF-8
+
+# Make sure there is no systemd process running as "debian" after the "enable
+# root" step in prepare-iaas-debian. If there are any proceses still running as
+# the "debian" user the "userdel" command below will fail.
+#
+# Depending on how long we have waited between running the "enable root"
+# script and this one it is possible the process has timed out on its own,
+# so run this command before doing "set -e" in case there is no process
+# to match.
+pkill -u debian -xf "/lib/systemd/systemd --user"
+
+# Make sure the process has gone away before continuing
+sleep_seconds=1
+attempt=1
+max_attempts=10
+while pgrep -u debian -xf "/lib/systemd/systemd --user"; do
+    if [ $attempt -gt $max_attempts ]; then
+        echo "failed waiting for systemd process to exit, please investigate"
+        exit 1
+    fi
+    echo "systemd process still running as debian user, this is attempt $attempt out of $max_attempts, sleeping for $sleep_seconds seconds..."
+    sleep $sleep_seconds
+    attempt=$((attempt + 1))
+done
+
+# From this point we expect all commands to succeed
+set -e
+
+# While the man page for "userdel" recommends using "deluser" we can not
+# run "deluser" with "--remove-home" without installing more than the
+# already included `perl-base` package, so stick with the low level
+# utility.
+userdel --remove debian
+rm /etc/sudoers.d/*
+
+# Make sure en_US.UTF-8 is present in the system, expected by at least
+# bootstrap-cosmos.sh
+locale_gen_file=/etc/locale.gen
+if grep -q '^# en_US.UTF-8 UTF-8$' $locale_gen_file; then
+    sed -i 's/^# \(en_US.UTF-8 UTF-8\)$/\1/' $locale_gen_file
+    locale-gen
+fi
+
+DEBIAN_FRONTEND="noninteractive" apt-get -y update
+DEBIAN_FRONTEND="noninteractive" apt-get -o Dpkg::Options::="--force-confnew" --fix-broken --assume-yes dist-upgrade
+reboot

--- a/prepare-iaas-debian
+++ b/prepare-iaas-debian
@@ -12,13 +12,17 @@ fi
 
 set -x
 
-ssh "debian@${ip}" sudo cp -r /home/debian/.ssh /root/
-ssh "debian@${ip}" sudo chown -R root:root /root/.ssh
-ssh "debian@${ip}" sudo chmod 700 /root/.ssh
-ssh "debian@${ip}" sudo chmod 600 /root/.ssh/authorized_keys
-ssh "root@${ip}" deluser debian
-ssh "root@${ip}" rm /home/debian -rf
-ssh "root@${ip}" rm /etc/sudoers.d/*
-ssh "root@${ip}" DEBIAN_FRONTEND="noninteractive" apt-get -y update
-ssh "root@${ip}" DEBIAN_FRONTEND="noninteractive" apt-get -o Dpkg::Options::="--force-confnew" --fix-broken --assume-yes dist-upgrade
-ssh "root@${ip}" reboot
+# Make sure we read the additional scripts from the same directory as
+# this script is located at
+script_dir=$(dirname "$0")
+
+# The reason for running two separate logins is that it is tricky to
+# remove the initial debian user while logged in as that same user:
+# ===
+# Removing user `debian' ...
+# Warning: group `debian' has no more members.
+# userdel: user debian is currently used by process 12081
+# /usr/sbin/deluser: `/sbin/userdel debian' returned error code 8. Exiting.
+# ===
+ssh "debian@${ip}" "bash -s" < "$script_dir"/debian-enable-root.sh
+ssh "root@${ip}" "bash -s" < "$script_dir"/debian-setup.sh


### PR DESCRIPTION
* Log in as few times as possible to not require a lot if yubikey keypresses
* Make sure en_US.UTF-8 is present
* Replace `rm -rf` with userdel command
* Make sure the debian account is actually deleted
* Remove locale related warnings when running script from macOS