### PR TITLE
Backport nunoc ops

### DIFF
--- a/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
+++ b/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-set -e
+#set -e 
+# not all breakage is un-recoverable...
 
 cmd_hostname="$1"
 if test -z "$cmd_hostname"; then
@@ -20,9 +21,8 @@ if test -z "$cmd_tags"; then
    exit 3
 fi
 
-set -x
-
-apt-get -y update && apt-get -y upgrade
+apt-get -y update
+apt-get -y upgrade
 for pkg in rsync git git-core wget; do
    apt-get -y install $pkg
 done

--- a/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
+++ b/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
@@ -31,7 +31,7 @@ export DEBIAN_FRONTEND='noninteractive'
 
 apt-get -y update
 apt-get -y upgrade
-for pkg in rsync git git-core wget; do
+for pkg in rsync git git-core wget gpg; do
    apt-get -y install $pkg
 done
 dpkg -i cosmos_1.5-1_all.deb

--- a/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
+++ b/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
@@ -22,7 +22,7 @@ fi
 
 set -x
 
-apt-get -y install rsync git-core wget
+apt-get -y update && apt-get -y upgrade && apt-get -y install rsync git git-core wget
 dpkg -i cosmos_1.5-1_all.deb
 
 if ! test -d /var/cache/cosmos/repo; then

--- a/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
+++ b/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
@@ -51,6 +51,12 @@ mv -f /etc/rc.local.new /etc/rc.local
 
 touch /etc/run-cosmos-at-boot
 
+# If this cloud-config is set, it will interfere with our changes to /etc/hosts
+grep -q 'manage_etc_hosts: true' /etc/cloud/cloud.cfg
+if [ ${?} -eq 0 ]; then
+    sed -i 's/manage_etc_hosts: true/manage_etc_hosts: false/g' /etc/cloud/cloud.cfg
+fi
+
 hostname $cmd_hostname
 short=`echo ${cmd_hostname} | awk -F. '{print $1}'`
 echo "127.0.1.1 ${cmd_hostname} ${short}" >> /etc/hosts

--- a/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
+++ b/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
@@ -33,6 +33,8 @@ if ! test -d /var/cache/cosmos/repo; then
 fi
 
 hostname $cmd_hostname
+short=`echo ${cmd_hostname} | awk -F. '{print $1}'`
+echo "127.0.1.1 ${cmd_hostname} ${short}" >> /etc/hosts
 
 perl -pi -e "s,#COSMOS_REPO_MODELS=.*,COSMOS_REPO_MODELS=\"\\\$COSMOS_REPO/global/:\\\$COSMOS_REPO/$cmd_hostname/\"," /etc/cosmos/cosmos.conf
 perl -pi -e "s,#COSMOS_UPDATE_VERIFY_GIT_TAG_PATTERN=.*,COSMOS_UPDATE_VERIFY_GIT_TAG_PATTERN=\"${cmd_tags}*\"," /etc/cosmos/cosmos.conf

--- a/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
+++ b/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
@@ -22,7 +22,10 @@ fi
 
 set -x
 
-apt-get -y update && apt-get -y upgrade && apt-get -y install rsync git git-core wget
+apt-get -y update && apt-get -y upgrade
+for pkg in rsync git git-core wget; do
+   apt-get -y install $pkg
+done
 dpkg -i cosmos_1.5-1_all.deb
 
 if ! test -d /var/cache/cosmos/repo; then

--- a/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
+++ b/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
@@ -57,6 +57,9 @@ if [ ${?} -eq 0 ]; then
     sed -i 's/manage_etc_hosts: true/manage_etc_hosts: false/g' /etc/cloud/cloud.cfg
 fi
 
+# Remove potential $hostname.novalocal line from /etc/hosts, added by cloud-init
+sed -i.bak -e "s/^127\.0\.1\.1 $(hostname)\..*novalocal.*//1" /etc/hosts
+
 hostname $cmd_hostname
 short=`echo ${cmd_hostname} | awk -F. '{print $1}'`
 echo "127.0.1.1 ${cmd_hostname} ${short}" >> /etc/hosts


### PR DESCRIPTION
Cherry-pick of all commits related to `global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh` in `nunoc-ops` repo.

Skipped `92a7d8c53dbc245e4afae94eef5d7955a0756015` because it would only revert more recent changes in `addhost`:
```
% git diff
diff --cc addhost
index 88f01023a,679cebd55..000000000
--- a/addhost
+++ b/addhost
@@@ -56,8 -50,8 +56,15 @@@ if [ ! -d "$cmd_fqdn" ]; the
  fi

  if [ "$cmd_do_bootstrap" = "yes" ]; then
++<<<<<<< HEAD
 +   scp apt/cosmos_1.5-2~sunet20220414_all.deb apt/bootstrap-cosmos.sh root@"$cmd_hostname":
 +   ssh root@"$cmd_hostname" ./bootstrap-cosmos.sh "$cmd_fqdn" "$rrepo" "$rtag"
 +   ssh root@"$cmd_hostname" cosmos update
 +   ssh root@"$cmd_hostname" cosmos apply
++=======
+    scp apt/cosmos_1.5-1_all.deb apt/bootstrap-cosmos.sh root@$cmd_hostname:
+    ssh root@$cmd_hostname ./bootstrap-cosmos.sh $cmd_fqdn $rrepo $rtag
+    ssh root@$cmd_hostname cosmos update
+    ssh root@$cmd_hostname cosmos apply
++>>>>>>> 92a7d8c53 (Added upstream change of how to fetch puppet deb:)
```
... as well as pulling in what appears to be an older version of `global/overlay/etc/cosmos/apt/puppetlabs-release-xenial.deb`.

Finally, some merge conflicts fixed related to `f6fe9285908764791613bd78b3a2aa683f910814`pulling in newer stuff at an earlier state.