### PR TITLE
Handle multiple versions of cosmos .deb

### DIFF
--- a/addhost
+++ b/addhost
@@ -56,7 +56,8 @@ if [ ! -d "$cmd_fqdn" ]; then
 fi
 
 if [ "$cmd_do_bootstrap" = "yes" ]; then
-   scp apt/cosmos_1.5-2~sunet20220414_all.deb apt/bootstrap-cosmos.sh root@"$cmd_hostname":
+   cosmos_deb=$(find apt/ -maxdepth 1 -name 'cosmos_*.deb' | sort -V | tail -1)
+   scp "$cosmos_deb" apt/bootstrap-cosmos.sh root@"$cmd_hostname":
    ssh root@"$cmd_hostname" ./bootstrap-cosmos.sh "$cmd_fqdn" "$rrepo" "$rtag"
    ssh root@"$cmd_hostname" cosmos update
    ssh root@"$cmd_hostname" cosmos apply

--- a/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
+++ b/global/overlay/etc/cosmos/apt/bootstrap-cosmos.sh
@@ -35,7 +35,8 @@ for pkg in rsync git git-core wget gpg; do
    # exist without stopping the script
    apt-get -y install $pkg || true
 done
-dpkg -i cosmos_1.5-1_all.deb
+cosmos_deb=$(find ./ -maxdepth 1 -name 'cosmos_*.deb' | sort -V | tail -1)
+dpkg -i "$cosmos_deb"
 
 if ! test -d /var/cache/cosmos/repo; then
     cosmos clone "$cmd_repo"


### PR DESCRIPTION
Before this change there was a need to keep addhost and bootstrap-cosmos.sh in sync regarding what version of the cosmos deb to scp over and later run.

Now we find the latest version as decided by `sort -V` in both addhost and bootstrap-cosmos.sh.

Solution discussed with @fredrikt.