### PR TITLE
`apt-get` doesn't really say yes…

### DIFF
--- a/iaas-setup.sh
+++ b/iaas-setup.sh
@@ -69,6 +69,6 @@ if grep -q '^# en_US.UTF-8 UTF-8$' $locale_gen_file; then
     locale-gen
 fi
 
-DEBIAN_FRONTEND="noninteractive" apt-get -y update
+DEBIAN_FRONTEND="noninteractive" apt -y update
 DEBIAN_FRONTEND="noninteractive" apt-get -o Dpkg::Options::="--force-confnew" --fix-broken --assume-yes dist-upgrade
 reboot


### PR DESCRIPTION
…or get right the question?

root@jocar-test-debian10:~# DEBIAN_FRONTEND="noninteractive" apt-get -y update Get:1 http://security.debian.org/debian-security buster/updates InRelease [34.8 kB] Get:2 http://deb.debian.org/debian buster InRelease [122 kB] Get:3 http://deb.debian.org/debian buster-updates InRelease [56.6 kB] Reading package lists... Done
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable' N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details. N: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Version' value from '10.6' to '10.13' E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable' N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details. E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates' N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.

root@jocar-test-debian10:~# DEBIAN_FRONTEND="noninteractive" apt -y update Get:1 http://deb.debian.org/debian buster InRelease [122 kB] Get:2 http://deb.debian.org/debian buster-updates InRelease [56.6 kB] Get:3 http://security.debian.org/debian-security buster/updates InRelease [34.8 kB] N: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Version' value from '10.6' to '10.13' E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable' N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details. Do you want to accept these changes and continue updating from this repository? [y/N] Y Get:4 http://deb.debian.org/debian buster/main Sources [7,852 kB] E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates' N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details. Do you want to accept these changes and continue updating from this repository? [y/N] Y Get:5 http://deb.debian.org/debian buster/main amd64 Packages [7,909 kB] Get:6 http://deb.debian.org/debian buster/main Translation-en [5,969 kB] Get:7 http://deb.debian.org/debian buster-updates/main Sources.diff/Index [12.1 kB] Ign:7 http://deb.debian.org/debian buster-updates/main Sources.diff/Index Get:8 http://deb.debian.org/debian buster-updates/main amd64 Packages.diff/Index [12.1 kB] Ign:8 http://deb.debian.org/debian buster-updates/main amd64 Packages.diff/Index Get:9 http://deb.debian.org/debian buster-updates/main Translation-en.diff/Index [6,148 B] Ign:9 http://deb.debian.org/debian buster-updates/main Translation-en.diff/Index Get:10 http://deb.debian.org/debian buster-updates/main Sources [4,616 B] Get:11 http://deb.debian.org/debian buster-updates/main amd64 Packages [8,788 B] Get:12 http://deb.debian.org/debian buster-updates/main Translation-en [6,915 B] E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable' N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details. Do you want to accept these changes and continue updating from this repository? [y/N] Y Get:13 http://security.debian.org/debian-security buster/updates/main Sources [297 kB] Get:14 http://security.debian.org/debian-security buster/updates/main amd64 Packages [423 kB] Get:15 http://security.debian.org/debian-security buster/updates/main Translation-en [229 kB]