### PR TITLE
iaas-setup.sh: support default user not existing

### DIFF
--- a/iaas-setup.sh
+++ b/iaas-setup.sh
@@ -26,39 +26,45 @@ fi
 # ===
 export LC_CTYPE=C.UTF-8
 
-# Make sure there is no systemd process running as the initial cloud image user
-# # after the "enable root" step in prepare-iaas-$os. If there are any #
-# proceses still running as the specified user the "userdel" command # below
-# will fail.
-#
-# Depending on how long we have waited between running the "enable root"
-# script and this one it is possible the process has timed out on its own,
-# so run this command before doing "set -e" in case there is no process
-# to match.
-pkill -u "$os" -xf "/lib/systemd/systemd --user"
+# Remove default user if present
+if id "$os"; then
+    # Make sure there is no systemd process running as the initial cloud image user
+    # after the "enable root" step in prepare-iaas-$os. If there are any
+    # proceses still running as the specified user the "userdel" command
+    # below will fail.
+    #
+    # Depending on how long we have waited between running the "enable root"
+    # script and this one it is possible the process has timed out on its own,
+    # so run this command before doing "set -e" in case there is no process
+    # to match.
+    pkill -u "$os" -xf "/lib/systemd/systemd --user"
 
-# Make sure the process has gone away before continuing
-sleep_seconds=1
-attempt=1
-max_attempts=10
-while pgrep -u "$os" -xf "/lib/systemd/systemd --user"; do
-    if [ $attempt -gt $max_attempts ]; then
-        echo "failed waiting for systemd process to exit, please investigate"
+    # Make sure the process has gone away before continuing
+    sleep_seconds=1
+    attempt=1
+    max_attempts=10
+    while pgrep -u "$os" -xf "/lib/systemd/systemd --user"; do
+        if [ $attempt -gt $max_attempts ]; then
+            echo "failed waiting for systemd process to exit, please investigate"
+            exit 1
+        fi
+        echo "systemd process still running as '$os' user, this is attempt $attempt out of $max_attempts, sleeping for $sleep_seconds seconds..."
+        sleep $sleep_seconds
+        attempt=$((attempt + 1))
+    done
+
+    # While the man page for "userdel" recommends using "deluser" we can not
+    # run "deluser" with "--remove-home" without installing more than the
+    # already included `perl-base` package on debian, so stick with the low
+    # level utility.
+    if ! userdel --remove "$os"; then
         exit 1
     fi
-    echo "systemd process still running as '$os' user, this is attempt $attempt out of $max_attempts, sleeping for $sleep_seconds seconds..."
-    sleep $sleep_seconds
-    attempt=$((attempt + 1))
-done
+fi
 
 # From this point we expect all commands to succeed
 set -e
 
-# While the man page for "userdel" recommends using "deluser" we can not
-# run "deluser" with "--remove-home" without installing more than the
-# already included `perl-base` package on debian, so stick with the low
-# level utility.
-userdel --remove "$os"
 rm /etc/sudoers.d/*
 
 # Make sure en_US.UTF-8 is present in the system, expected by at least


### PR DESCRIPTION
For CNaaS machines we supply cloud-init user-data that does not create a default user, in this case the script would exit half-way through. Now it only tries to remove a user if it exists in the first place.