### PR TITLE
Only update the database when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ cosmos:
 upgrade:
 	fab upgrade
 
-db:
+db: global/overlay/etc/puppet/cosmos-db.yaml
+
+global/overlay/etc/puppet/cosmos-db.yaml: global/overlay/etc/puppet/cosmos-rules.yaml:
 	@python ./fabfile/db.py > global/overlay/etc/puppet/cosmos-db.yaml
 	@git add global/overlay/etc/puppet/cosmos-db.yaml && git commit -m "update db" global/overlay/etc/puppet/cosmos-db.yaml
 


### PR DESCRIPTION
Without this fix:
```
➜  nunoc-ops git:(master) make db
On branch master
Your branch is up to date with 'origin/master'.

nothing to commit, working tree clean
make: *** [db] Error 1
```

With this fix:
```
➜  swamid-ops git:(master) ✗ make db
make: Nothing to be done for `db'.
```

Will make it easier to only use `make tag` when to sign changes.