### PR TITLE
Make sure of separator

### DIFF
--- a/edit-secrets
+++ b/edit-secrets
@@ -151,7 +151,7 @@ function edit_file_on_host() {
 	edit_gpg_file ${SECRETFILE}
     elif [ -f /etc/hiera/eyaml/public_certkey.pkcs7.pem ]; then
 	# default to eyaml if the key exists and none of the secrets-file above exist
-	touch ${EYAMLFILE}
+	echo "---" > ${EYAMLFILE}
 	edit_eyaml_file ${EYAMLFILE}
     fi
 }


### PR DESCRIPTION
We use the separator later on to determine where the yaml document starts. `eyaml edit` adds the separator to new (non-existing) files by itself but since we want to create the file before in order to diff later the separator needs to be added in order to get a valid document.