### PR TITLE
Add support for eyaml in Hiera

### DIFF
--- a/global/overlay/etc/puppet/hiera.yaml
+++ b/global/overlay/etc/puppet/hiera.yaml
@@ -1,21 +1,27 @@
+# Hiera version 5 configuration
+#
 ---
-:backends:
-  - yaml
-  - gpg
+version: 5
+defaults:
+  datadir: /etc/hiera/data
+  data_hash: yaml_data
 
-:logger: console
+hierarchy:
+  - name: "Per-node data"
+    path: "local.yaml"
 
-:hierarchy:
-  - "%{env}/%{location}/%{calling_module}"
-  - "%{env}/%{calling_module}"
-  - local
-  - secrets.yaml
-  - common
+  - name: "Per-group data"
+    path: "group.yaml"
 
+  - name: "Per-host secrets"
+    path: "local.eyaml"
+    lookup_key: eyaml_lookup_key
+    options:
+      pkcs7_private_key: /etc/hiera/eyaml/private_key.pkcs7.pem
+      pkcs7_public_key:  /etc/hiera/eyaml/public_certkey.pkcs7.pem
 
-:yaml:
-   :datadir: /etc/hiera/data
+  - name: "Overrides per distribution"
+    path: "dist_%{::lsbdistcodename}_override.yaml"
 
-:gpg:
-   :datadir: /etc/hiera/data
-   :key_dir: /etc/hiera/gpg
+  - name: "Data common to whole environment"
+    path: "common.yaml"


### PR DESCRIPTION
And at the same time remove support for gpg.

The modern version of the configuration (v5) has been tested with 20.04 but might work with older dists.