### PR TITLE
Add additional packages for use with debian 12

### DIFF
--- a/global/pre-tasks.d/030puppet
+++ b/global/pre-tasks.d/030puppet
@@ -13,7 +13,7 @@ if ! test -f "${stamp}" -a -f /usr/bin/puppet; then
     . /etc/os-release
 
     # Note: in posix shell, string comparison is done with a single =
-    if [ ${ID} = "debian" ] && [ ${VERSION_ID} -ge 12 ]; then
+    if [ "${ID}" = "debian" ] && [ "${VERSION_ID}" -ge 12 ]; then
       apt-get -y install cron puppet-module-puppetlabs-cron-core puppet-module-camptocamp-augeas
     fi
 

--- a/global/pre-tasks.d/030puppet
+++ b/global/pre-tasks.d/030puppet
@@ -7,10 +7,17 @@ set -e
 
 stamp="$COSMOS_BASE/stamps/puppet-tools-v01.stamp"
 
-if ! test -f $stamp -a -f /usr/bin/puppet; then
+if ! test -f "${stamp}" -a -f /usr/bin/puppet; then
     apt-get update
     apt-get -y install puppet
+    . /etc/os-release
 
-    mkdir -p `dirname $stamp`
-    touch $stamp
+    # Note: in posix shell, string comparison is done with a single =
+    if [ ${ID} = "debian" ] && [ ${VERSION_ID} -ge 12 ]; then
+      apt-get -y install cron puppet-module-puppetlabs-cron-core puppet-module-camptocamp-augeas
+    fi
+
+    mkdir -p "$(dirname "${stamp}")"
+    touch "${stamp}"
 fi
+


### PR DESCRIPTION
This patch will install three packages that is needed for normal operations of puppet using puppet-sunet with multiverse on Debian 12:

cron puppet-module-puppetlabs-cron-core puppet-module-camptocamp-augeas