### PR TITLE
    bump-tag: Compare against current branch

### DIFF
--- a/bump-tag
+++ b/bump-tag
@@ -25,7 +25,8 @@ if [[ -n ${last_tag} ]]; then
   echo ""
 
   echo "Differences between tag ${last_tag} and what you are about to sign:"
-  env PAGER=cat git diff --color "${last_tag}..main"
+  this_branch=$(git rev-parse --abbrev-ref HEAD)
+  env PAGER=cat git diff --color "${last_tag}..${this_branch}"
 
   iter=1
   ok=


### PR DESCRIPTION
Mariah pointed out that this was lost in:
    
https://github.com/SUNET/multiverse/commit/6ac9294dea377245ce6947e053da753a9a3b9ba7
    
And should be reinstated