### PR TITLE
Enforce more strict permissions for files in Cosmos

### DIFF
--- a/global/post-tasks.d/010fix-ssh-perms
+++ b/global/post-tasks.d/010fix-ssh-perms
@@ -17,7 +17,7 @@ if test -f /root/.ssh/authorized_keys; then
     if test `stat -t /root/.ssh/authorized_keys | cut -d\  -f5` != 0; then
 	chown root.root /root/.ssh/authorized_keys
     fi
-    if test `stat --printf=%a /root/.ssh/authorized_keys` != 600; then
-	chmod 600 /root/.ssh/authorized_keys
+    if test `stat --printf=%a /root/.ssh/authorized_keys` != 440; then
+	chmod 440 /root/.ssh/authorized_keys
     fi
 fi

--- a/global/post-tasks.d/014set-cosmos-permissions
+++ b/global/post-tasks.d/014set-cosmos-permissions
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Set Cosmos directory permissions so that
+# the files cannot be read by anyone but root,
+# since it's possible that the directory
+# can contain files that after applying the
+# overlay to / only should be read or writable
+# by root.
+
+set -e
+self=$(basename "$0")
+
+if ! test -d "$COSMOS_BASE"; then
+    test -z "$COSMOS_VERBOSE" || echo "$self: COSMOS_BASE was not found. Aborting change of permissions."
+    exit 0
+fi
+
+args=""
+if [ "x$COSMOS_VERBOSE" = "xy" ]; then
+    args="-v"
+fi
+
+chown ${args} root:root "$COSMOS_BASE"
+chmod ${args} 750 "$COSMOS_BASE"

--- a/global/pre-tasks.d/014set-cosmos-permissions
+++ b/global/pre-tasks.d/014set-cosmos-permissions
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Set Cosmos directory permissions so that
+# the files cannot be read by anyone but root,
+# since it's possible that the directory
+# can contain files that after applying the
+# overlay to / only should be read or writable
+# by root.
+
+set -e
+self=$(basename "$0")
+
+if ! test -d "$COSMOS_BASE"; then
+    test -z "$COSMOS_VERBOSE" || echo "$self: COSMOS_BASE was not found. Aborting change of permissions."
+    exit 0
+fi
+
+args=""
+if [ "x$COSMOS_VERBOSE" = "xy" ]; then
+    args="-v"
+fi
+
+chown ${args} root:root "$COSMOS_BASE"
+chmod ${args} 750 "$COSMOS_BASE"

--- a/global/pre-tasks.d/015set-overlay-permissions
+++ b/global/pre-tasks.d/015set-overlay-permissions
@@ -14,10 +14,17 @@ if ! test -d "$MODEL_OVERLAY"; then
     exit 0
 fi
 
+args=""
+if [ "x$COSMOS_VERBOSE" = "xy" ]; then
+    args="-v"
+fi
+
 if [ -d "$MODEL_OVERLAY/root" ]; then
-    args=""
-    if [ "x$COSMOS_VERBOSE" = "xy" ]; then
-        args="-v"
-    fi
+    chown ${args} root:root "$MODEL_OVERLAY"/root
     chmod ${args} 0700 "$MODEL_OVERLAY"/root
+fi
+
+if [ -d "$MODEL_OVERLAY/root/.ssh" ]; then
+    chown ${args} -R root:root "$MODEL_OVERLAY"/root/.ssh
+    chmod ${args} 0700 "$MODEL_OVERLAY"/root/.ssh
 fi


### PR DESCRIPTION
This is a merge of various stricter permissions for Cosmos that were identified to be needed when setting up the locked down Tor signing OPS repo to avoid information leakage and possible unauthorized modification by unprivileged users.

The main issue is to restrict access to $COSMOS_BASE at the earliest stage possible to avoid race conditions, during which information could be leaked or modifications made.
Permissions for sensitive files and directories such as /root and /root/.ssh in the overlay are checked separately. A fix is also included to apply the same permission for /root/.ssh/authorized_keys that Puppet applies through sunet::ssh_keys to avoid changing permissions on each run of Cosmos and Puppet.