### PR TITLE
PREPARE/ADDHOST: allow the ues of proxyjump with ip address

### DIFF
--- a/addhost
+++ b/addhost
@@ -13,11 +13,12 @@ function usage() {
    echo "  <host> can be an IP number, or something that resolves to one"
 }
 
-while getopts "bhn:" this; do
+while getopts "bhnp:" this; do
    case "${this}" in
       h) usage; exit 0;;
       b) cmd_do_bootstrap="yes" ;;
       n) cmd_fqdn="${OPTARG}" ; shift ;;
+      p) cmd_proxy="${OPTARG}" ; shift ;;
       *) echo "Unknown option ${this}"; echo ""; usage; exit 1;;
    esac
 done
@@ -34,6 +35,10 @@ fi
 if test -z "$cmd_hostname"; then
     usage
     exit 1
+fi
+
+if [[ -n $cmd_proxy ]]; then
+  proxyjump="-o ProxyJump=${cmd_proxy}"
 fi
 
 test -f cosmos.conf && . ./cosmos.conf
@@ -57,8 +62,8 @@ fi
 
 if [ "$cmd_do_bootstrap" = "yes" ]; then
    cosmos_deb=$(find apt/ -maxdepth 1 -name 'cosmos_*.deb' | sort -V | tail -1)
-   scp "$cosmos_deb" apt/bootstrap-cosmos.sh root@"$cmd_hostname":
-   ssh root@"$cmd_hostname" ./bootstrap-cosmos.sh "$cmd_fqdn" "$rrepo" "$rtag"
-   ssh root@"$cmd_hostname" cosmos update
-   ssh root@"$cmd_hostname" cosmos apply
+   scp $proxyjump "$cosmos_deb" apt/bootstrap-cosmos.sh root@"$cmd_hostname":
+   ssh root@"$cmd_hostname" $proxyjump ./bootstrap-cosmos.sh "$cmd_fqdn" "$rrepo" "$rtag"
+   ssh root@"$cmd_hostname" $proxyjump cosmos update
+   ssh root@"$cmd_hostname" $proxyjump cosmos apply
 fi

--- a/prepare-iaas-debian
+++ b/prepare-iaas-debian
@@ -1,5 +1,6 @@
 #!/bin/bash
 ip="${1}"
+ssh_proxy="${2}"
 
 if [[ -z "${ip}" ]]; then
     echo "Please specify a cloud image host that the script should do the following on:"
@@ -8,6 +9,9 @@ if [[ -z "${ip}" ]]; then
     echo "  #3 run apt-get update and dist-upgrade without interaction"
     echo "  #4 reboot to start using the new kernel, updated packages etc."
     exit 1
+fi
+if [[ -n "${ssh_proxy}" ]]; then
+  proxyjump="-o ProxyJump=${ssh_proxy}"
 fi
 
 set -x
@@ -21,5 +25,5 @@ script_dir=$(dirname "$0")
 # ===
 # userdel: user debian is currently used by process 1082
 # ===
-ssh "debian@${ip}" "bash -s" < "$script_dir"/iaas-enable-root.sh
-ssh "root@${ip}" "bash -s" < "$script_dir"/iaas-setup.sh
+ssh "debian@${ip}" ${proxyjump} "bash -s" < "$script_dir"/iaas-enable-root.sh
+ssh "root@${ip}" ${proxyjump} "bash -s" < "$script_dir"/iaas-setup.sh

--- a/prepare-iaas-ubuntu
+++ b/prepare-iaas-ubuntu
@@ -1,5 +1,6 @@
 #!/bin/bash
 ip="${1}"
+ssh_proxy="${2}"
 
 if [[ -z "${ip}" ]]; then
     echo "Please specify a cloud image host that the script should do the following on:"
@@ -10,6 +11,9 @@ if [[ -z "${ip}" ]]; then
     exit 1
 fi
 
+if [[ -n "${ssh_proxy}" ]]; then
+  proxyjump="-o ProxyJump=${ssh_proxy}"
+fi
 set -x
 
 # Make sure we read the additional scripts from the same directory as
@@ -21,5 +25,5 @@ script_dir=$(dirname "$0")
 # ===
 # userdel: user ubuntu is currently used by process 44063
 # ===
-ssh "ubuntu@${ip}" "bash -s" < "$script_dir"/iaas-enable-root.sh
-ssh "root@${ip}" "bash -s" < "$script_dir"/iaas-setup.sh
+ssh "ubuntu@${ip}" ${proxyjump} "bash -s" < "$script_dir"/iaas-enable-root.sh
+ssh "root@${ip}" ${proxyjump} "bash -s" < "$script_dir"/iaas-setup.sh


### PR DESCRIPTION
With this patch you can specify a ProxyJump for prepare-iaas-ubuntu, prepare-iaas-debian and addhost. Example:

./prepare-iaas-debian 89.47.191.7 hj
./addhost -b -n node1.extern.drive.test.sunet.se -p hj -- 89.47.191.7

where hj is a host defined in my .ssh/config suitable for a proxyjump to the host in question.

This makes it easier to use ip addresses for these scripts which might be neccessary if dns takes a while to propagate.