### PR TITLE
Allow empty hosts

### DIFF
--- a/global/overlay/etc/puppet/cosmos_enc.py
+++ b/global/overlay/etc/puppet/cosmos_enc.py
@@ -26,7 +26,8 @@ found = False
 classes = dict()
 for reg, cls in rules.items():
     if re.search(reg, node_name):
-        classes.update(cls)
+        if cls:
+            classes.update(cls)
         found = True
 
 if not found:


### PR DESCRIPTION
If a host is specified in `cosmos-rules.yaml` with no classes assigned.