### PR TITLE
Ubuntu-24 fixes

### DIFF
--- a/global/overlay/etc/puppet/hiera.yaml
+++ b/global/overlay/etc/puppet/hiera.yaml
@@ -21,7 +21,7 @@ hierarchy:
       pkcs7_public_key:  /etc/hiera/eyaml/public_certkey.pkcs7.pem
 
   - name: "Overrides per distribution"
-    path: "dist_%{::lsbdistcodename}_override.yaml"
+    path: "dist_%{facts.os.distro.codename}_override.yaml"
 
   - name: "Data common to whole environment"
     path: "common.yaml"

--- a/global/pre-tasks.d/030puppet
+++ b/global/pre-tasks.d/030puppet
@@ -13,7 +13,7 @@ if ! test -f "${stamp}" -a -f /usr/bin/puppet; then
     . /etc/os-release
 
     # Note: in posix shell, string comparison is done with a single =
-    if [ "${ID}" = "debian" ] && [ "${VERSION_ID}" -ge 12 ]; then
+    if [ "${ID}" = "debian" ] && [ "${VERSION_ID}" -ge 12 ] || ([ "${ID}" = "ubuntu" ] && $(dpkg --compare-versions ${VERSION_ID} ge 24.04)) ; then
       apt-get -y install \
           cron \
           puppet-module-camptocamp-augeas \


### PR DESCRIPTION
Fixes needed for modern puppet (8.4.0) that is default in ubuntu-24