### PR TITLE
patch for broken eyaml in ubuntu24.04.

### DIFF
--- a/edit-secrets
+++ b/edit-secrets
@@ -73,6 +73,41 @@ EOF
     fi
 }
 
+function patch_broken_eyaml_noble {
+    #
+    # Ubuntu 24.04 (noble) has a hiera-eyaml version that is incompatible with ruby 3.2+ (default in ubuntu24).
+    # This is fixed in hiera-eyaml version 3.3.0: https://github.com/voxpupuli/hiera-eyaml/pull/340/files
+    # https://github.com/voxpupuli/hiera-eyaml/blob/master/CHANGELOG.md
+    # But there is no modern version of hiera-eyanl packaged in debian or ubuntu.
+    # https://github.com/puppetlabs/puppet/wiki/Puppet-8-Compatibility#filedirexists-removed
+    #
+
+    . /etc/os-release
+    if [ "${VERSION_CODENAME}" == "noble" ]; then
+        plugins_file="/usr/share/rubygems-integration/all/gems/hiera-eyaml-3.3.0/lib/hiera/backend/eyaml/subcommands/edit.rb"
+        if [ -f $plugins_file ]; then
+            # We only want to try patching the file if it is the known broken version
+            bad_sum="59c6eb910ab2eb44f8c75aeaa79bff097038feb673b5c6bdccde23d9b2a393e2"
+            sum=$(sha256sum $plugins_file | awk '{print $1}')
+            if [ "$sum" == "$bad_sum" ]; then
+                patch --fuzz=0 --directory=/ --strip=0 <<'EOF'
+--- /usr/share/rubygems-integration/all/gems/hiera-eyaml-3.3.0/lib/hiera/backend/eyaml/subcommands/edit.rb.orig	2022-06-11 16:30:10.000000000 +0000
++++ /usr/share/rubygems-integration/all/gems/hiera-eyaml-3.3.0/lib/hiera/backend/eyaml/subcommands/edit.rb	2024-09-09 14:13:19.306342025 +0000
+@@ -59,7 +59,7 @@
+             Optimist::die "You must specify an eyaml file" if ARGV.empty?
+             options[:source] = :eyaml
+             options[:eyaml] = ARGV.shift
+-            if File.exists? options[:eyaml]
++            if File.exist? options[:eyaml]
+               begin
+                 options[:input_data] = File.read options[:eyaml]
+               rescue
+EOF
+            fi
+        fi
+    fi
+}
+
 function edit_copy_and_commit()
 {
     #
@@ -234,6 +269,7 @@ function edit_eyaml_file()
     done
 
     patch_broken_eyaml
+    patch_broken_eyaml_noble
 
     # save source file for comparision afterwards
     cp "${EYAMLFILE}" "${TMPFILE}"

--- a/edit-secrets
+++ b/edit-secrets
@@ -71,14 +71,12 @@ EOF
             fi
         fi
     fi
-}
 
-function patch_broken_eyaml_noble {
     #
     # Ubuntu 24.04 (noble) has a hiera-eyaml version that is incompatible with ruby 3.2+ (default in ubuntu24).
     # This is fixed in hiera-eyaml version 3.3.0: https://github.com/voxpupuli/hiera-eyaml/pull/340/files
     # https://github.com/voxpupuli/hiera-eyaml/blob/master/CHANGELOG.md
-    # But there is no modern version of hiera-eyanl packaged in debian or ubuntu.
+    # But there is no modern version of hiera-eyaml packaged in debian or ubuntu.
     # https://github.com/puppetlabs/puppet/wiki/Puppet-8-Compatibility#filedirexists-removed
     #
 
@@ -269,7 +267,6 @@ function edit_eyaml_file()
     done
 
     patch_broken_eyaml
-    patch_broken_eyaml_noble
 
     # save source file for comparision afterwards
     cp "${EYAMLFILE}" "${TMPFILE}"


### PR DESCRIPTION
patch using the same methodology as before when ubuntu22.04 was broken: https://github.com/SUNET/multiverse/commit/a7d0a189da5c4c465aa1f2b60dc8daedab71679b