### PR TITLE
cosmos-cron-wrapper: Add '--random-sleep'

### DIFF
--- a/global/overlay/usr/local/libexec/cosmos-cron-wrapper
+++ b/global/overlay/usr/local/libexec/cosmos-cron-wrapper
@@ -2,7 +2,7 @@
 
 test -f /etc/no-automatic-cosmos && exit 0
 
-RUN_COSMOS='/usr/local/bin/run-cosmos'
+RUN_COSMOS='/usr/local/bin/run-cosmos --random-sleep'
 SCRIPTHERDER_CMD=''
 
 if [ -x /usr/local/bin/scriptherder ]; then


### PR DESCRIPTION
Now that run-cosmos in multiverse understands --random-sleep, use it in the cron wrapper to make machines spread out the load.