### PR TITLE
Fix bug in shared cosmos code example

### DIFF
--- a/docs/shared_cosmos.mkd
+++ b/docs/shared_cosmos.mkd
@@ -27,15 +27,20 @@ class <CLASS-NAME> {
 
   $shared_cosmos_key_exists = find_file($shared_cosmos_key)
 
+  $shared_cosmos_hiera_key = lookup('shared_cosmos_hiera_key', Optional[String], 'first', undef)
+
   # run-cosmos has to run twice before this condition will pass
   if $shared_cosmos_key_exists {
     <CODE USING THE SHARED SECRET>
   }
-  else {
+  elsif $shared_cosmos_hiera_key {
     warning("Missing ${shared_cosmos_key} - trying to create file.")
     sunet::snippets::secret_file { $shared_cosmos_key:
       hiera_key => 'shared_cosmos_hiera_key'
     }
+  }
+  else {
+    warning("Missing ${shared_cosmos_key} and Hiera key 'shared_cosmos_hiera_key' not found - skipping file creation.")
   }
 }
 ```


### PR DESCRIPTION
I found a minor bug in the code example that I used for shared cosmos.
If cosmos runs before you've added the shared cosmos key to local.eyaml, then puppet will add an empty file if 'shared_cosmos_hiera_key' doesn't exist. Thus each subsequent execution of cosmos will try to use the key which is empty, causing errors.