### PR TITLE
ubuntu26 - python3-debian package is not installed

### DIFF
--- a/global/pre-tasks.d/030puppet
+++ b/global/pre-tasks.d/030puppet
@@ -10,6 +10,7 @@ stamp="$COSMOS_BASE/stamps/puppet-tools-v01.stamp"
 if ! test -f "${stamp}" -a -f /usr/bin/puppet; then
 	apt-get update
 	apt-get -y install puppet
+	apt-get -y python3-debian
 	# shellcheck source=/dev/null
 	. /etc/os-release
 

--- a/global/pre-tasks.d/030puppet
+++ b/global/pre-tasks.d/030puppet
@@ -10,7 +10,7 @@ stamp="$COSMOS_BASE/stamps/puppet-tools-v01.stamp"
 if ! test -f "${stamp}" -a -f /usr/bin/puppet; then
 	apt-get update
 	apt-get -y install puppet
-	apt-get -y python3-debian
+	apt-get -y install python3-debian
 	# shellcheck source=/dev/null
 	. /etc/os-release
 


### PR DESCRIPTION
This is used in the setup-cosmos-modules script.
So by this we make sure that it is available.